### PR TITLE
Use originalRefName when querying sequenceAdapter

### DIFF
--- a/src/ImportanceAdapter/ImportanceAdapter.ts
+++ b/src/ImportanceAdapter/ImportanceAdapter.ts
@@ -51,18 +51,20 @@ export default class ImportanceAdapter extends BaseFeatureDataAdapter {
     return this.wiggleAdapter.getGlobalStats(opts)
   }
 
-  public getFeatures(region: NoAssemblyRegion, opts: WiggleOptions = {}) {
+  public getFeatures(
+    region: NoAssemblyRegion & { originalRefName?: string },
+    opts: WiggleOptions = {},
+  ) {
     const { refName } = region
     const { signal } = opts
     return ObservableCreate<Feature>(async observer => {
       const features = this.wiggleAdapter.getFeatures(region, opts)
-      const sequence = this.sequenceAdapter.getFeatures(region, opts)
+      const sequence = this.sequenceAdapter.getFeatures(
+        { ...region, refName: region.originalRefName },
+        opts,
+      )
       const featureArray = await features.pipe(toArray()).toPromise()
       const sequenceFeatureArray = await sequence.pipe(toArray()).toPromise()
-
-      console.log(region)
-      console.log(sequence)
-      console.log(sequenceFeatureArray)
 
       const seqString = sequenceFeatureArray[0].get('seq')
       const scoreArray = new Array(region.end - region.start)


### PR DESCRIPTION
This uses the originalRefName prop for querying the sequenceAdapter

This is a funny thing that has to be done when querying the sequenceAdapter to make sure that it gets the proper refName, and it can be seen in CramAdapter seqFetch for example

This is an interesting issue taken to the generic point of view, because it is unknown what the code will do if there are many alternative refNames for many subadapters....not sure if it can really be solved properly, but this should fix it for the sequence subadapter